### PR TITLE
Add rawMode parameter for interactive command execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "tmux-mcp",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tmux-mcp",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.2",
         "uuid": "^11.1.0",
         "zod": "^3.22.4"
+      },
+      "bin": {
+        "tmux-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.10.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,11 +231,12 @@ server.tool(
   "Execute a command in a tmux pane and get results. IMPORTANT: Avoid heredoc syntax (cat << EOF) and other multi-line constructs as they conflict with command wrapping. For file writing, prefer: printf 'content\\n' > file, echo statements, or write to temp files instead.",
   {
     paneId: z.string().describe("ID of the tmux pane"),
-    command: z.string().describe("Command to execute")
+    command: z.string().describe("Command to execute"),
+    rawMode: z.boolean().optional().describe("Execute command without wrapper markers for REPL/interactive compatibility. Disables get-command-result status tracking. Use capture-pane to monitor interactive apps.")
   },
-  async ({ paneId, command }) => {
+  async ({ paneId, command, rawMode }) => {
     try {
-      const commandId = await tmux.executeCommand(paneId, command);
+      const commandId = await tmux.executeCommand(paneId, command, rawMode);
 
       // Create the resource URI for this command's results
       const resourceUri = `tmux://command/${commandId}/result`;
@@ -283,7 +284,11 @@ server.tool(
       // Format the response based on command status
       let resultText;
       if (command.status === 'pending') {
-        resultText = `Command still executing...\nStarted: ${command.startTime.toISOString()}\nCommand: ${command.command}`;
+        if (command.result) {
+          resultText = `Status: ${command.status}\nCommand: ${command.command}\n\n--- Message ---\n${command.result}`;
+        } else {
+          resultText = `Command still executing...\nStarted: ${command.startTime.toISOString()}\nCommand: ${command.command}`;
+        }
       } else {
         resultText = `Status: ${command.status}\nExit code: ${command.exitCode}\nCommand: ${command.command}\n\n--- Output ---\n${command.result}`;
       }
@@ -442,7 +447,11 @@ server.resource(
       // Format the response based on command status
       let resultText;
       if (command.status === 'pending') {
-        resultText = `Command still executing...\nStarted: ${command.startTime.toISOString()}\nCommand: ${command.command}`;
+        if (command.result) {
+          resultText = `Status: ${command.status}\nCommand: ${command.command}\n\n--- Message ---\n${command.result}`;
+        } else {
+          resultText = `Command still executing...\nStarted: ${command.startTime.toISOString()}\nCommand: ${command.command}`;
+        }
       } else {
         resultText = `Status: ${command.status}\nExit code: ${command.exitCode}\nCommand: ${command.command}\n\n--- Output ---\n${command.result}`;
       }


### PR DESCRIPTION
# Problem
Interactive applications like REPLs, editors, and long-running processes don't work with the current wrapper-based command execution, as the wrapper markers interfere with their operation (see #1).

# Solution
Adds a `rawMode` parameter to the `execute-command` tool that skips wrapper markers when enabled, allowing proper interaction with REPLs and other interactive applications.

## Changes
- Add `rawMode` boolean parameter to `execute-command` tool
- Update command execution logic to skip wrapper markers when `rawMode=true`
- Fix status checking to properly display error messages for pending commands
- Add clear documentation explaining rawMode disables status tracking and directs users to use `capture-pane` for monitoring

## Usage
```typescript
// For interactive applications
await executeCommand(paneId, "python3", true);  // rawMode=true

// For regular commands (existing behavior)
await executeCommand(paneId, "ls -la");  // rawMode defaults to false
```

## Testing
Tested with:
- Python REPL - commands execute properly and maintain interactive state
- Interactive quiz application - full user interaction works seamlessly
- Status checking shows appropriate error message directing users to `capture-pane`

Closes #1